### PR TITLE
Update package.json build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,10 @@
   },
   "scripts": {
     "start": "cross-env REACT_APP_IN_GAME=1 webpack-cli serve",
-    "build": "cross-env REACT_APP_IN_GAME=1 webpack --mode=production",
+    "build": "yarn build:server & yarn build:client & yarn build:web",
+    "build:web": "cross-env REACT_APP_IN_GAME=1 webpack --mode=production",
+    "build:server": "esbuild server/server.ts --bundle --sourcemap --platform=node --outfile=dist/server.js",
+    "build:client": "esbuild client/client.ts --bundle --outfile=dist/client.js",
     "dev": "cross-env REACT_APP_IN_GAME=0 webpack-dev-server --mode=development",
     "serve": "serve dist -p 3002",
     "clean": "rm -rf dist",
@@ -42,8 +45,6 @@
     "watch:nui": "esbuild src/index.tsx --outdir=dist/html --watch --target=es6 --bundle --loader:.png=dataurl",
     "watch:client": "esbuild client/client.ts --bundle --watch --outfile=dist/client.js",
     "watch:server": "esbuild server/server.ts --bundle --sourcemap --platform=node --watch --outfile=dist/server.js",
-    "build:client": "esbuild client/client.ts --bundle --outfile=dist/client.js",
-    "build:server": "esbuild server/server.ts --bundle --sourcemap --platform=node --outfile=dist/server.js",
     "dev:server": "esbuild server/server.ts --bundle --platform=node --outfile=dist/server.js && node dist/server.js",
     "build:game": "yarn build:client && yarn build:server"
   },


### PR DESCRIPTION
The build script was not calling the `build:client` and `build:server` scripts. As a result if the user simply ran `yarn build`, it was not building all of the files.

As a result of the incomplete errors, users would see `Unexpected end of JSON input` whenever they called a fetchNui event.

Resolves this issue: https://github.com/npwd-community/npwd_advertisements/issues/8